### PR TITLE
chore(docs): update copy for IBM.com Library

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,21 +30,21 @@ If you want to help improve the docs, it's a good idea to let others know what y
 
 ### Setup
 
-1. Fork the project by navigating to the main [repository](https://github.com/IBM/carbon-addons-dotcom) and clicking the **Fork** button on the top-right corner.
+1. Fork the project by navigating to the main [repository](https://github.com/carbon-design-system/dotcom-library/) and clicking the **Fork** button on the top-right corner.
 
 2. Navigate to your forked repository and copy the **SSH url**. Clone your fork by running the following in your terminal:
 
    ```
-   $ git clone git@github.com:{ YOUR_USERNAME }/carbon-addons-dotcom.git
-   $ cd carbon-addons-dotcom
+   $ git clone git@github.com:{ YOUR_USERNAME }/dotcom-library.git
+   $ cd dotcom-library
    ```
 
    See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more details on forking a repository.
 
-3. Once cloned, you will see `origin` as your default remote, pointing to your personal forked repository. Add a remote named `upstream` pointing to the main `carbon-addons-dotcom`:
+3. Once cloned, you will see `origin` as your default remote, pointing to your personal forked repository. Add a remote named `upstream` pointing to the main `dotcom-library`:
 
    ```
-   $ git remote add upstream git@github.com:IBM/carbon-addons-dotcom.git
+   $ git remote add upstream git@github.com:carbon-design-system/dotcom-library.git
    $ git remote -v
    ```
 
@@ -92,7 +92,7 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue. H
    $ git push origin { YOUR_BRANCH_NAME }
    ```
 
-8. In Github, navigate to [IBM/carbon-addons-dotcom](https://github.com/IBM/carbon-addons-dotcom) and click the button that reads "Compare & pull request".
+8. In Github, navigate to [carbon-design-system/dotcom-library](https://github.com/carbon-design-system/dotcom-library/) and click the button that reads "Compare & pull request".
 
 9. Write a title and description, then click "Create pull request".
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ about: Something isn't working as expected? Here is the right place to report.
 
 > What browser are you working in?
 
-> What version of the Carbon Design System are you using?
+> What version of the IBM.com Library are you using?
 
 > What offering/product do you work on? Any pressing ship or release dates we should be aware of?
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,20 +1,20 @@
 ---
 name: Question 🤔
-about: Usage question or discussion about the Carbon Design System.
+about: Usage question or discussion about the IBM.com Library.
 ---
 
 <!--
 
-Hi there! 👋 Hope everything is going okay using projects from the Carbon Design
-System. It looks like you might have a question about our work, so we wanted to
+Hi there! 👋 Hope everything is going okay using projects from the IBM.com
+Library. It looks like you might have a question about our work, so we wanted to
 share a couple resources that you could use if you haven't tried them yet 🙂.
 
 If you're an IBMer, we have a couple of Slack channels available across all IBM
 Workspaces:
 
+- #ibm-digital-design for questions about the IBM.com Library
 - #carbon-design-system for questions about the Design System
 - #carbon-components for questions about component styles
-- #carbon-react for questions about our React components
 
 If these resources don't work out, help us out by filling out a couple of
 details below!

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,7 +1,7 @@
 # Support
 
 If you run into an issue, sorry about that! We definitely want to make sure that
-your experience using the Carbon Design System is the best that it can be.
+your experience using the IBM.com Library is the best that it can be.
 
 When this happens, just create an issue on GitHub by filling out the template
 and we'll try our best to respond in a reasonable time.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-  <title>Carbon Design System Sandbox</title>
+  <title>IBM.com Library Sandbox</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="//unpkg.com/carbon-components@latest/css/carbon-components.min.css">
   <link rel="stylesheet" href="src/styles.css">

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "carbon-addons-dotcom",
+  "name": "ibm-dotcom-library",
   "version": "0.0.0",
   "description": "This library is an extension of the Carbon IBM Design System. It contains unique components shared between the IBM.com user journeys to unify its look and feel.",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/IBM/carbon-addons-dotcom/issues"
+    "url": "https://github.com/carbon-design-system/dotcom-library/issues"
   },
-  "repository": "git@github.com:IBM/carbon-addons-dotcom.git",
+  "repository": "git@github.com:carbon-design-system/dotcom-library.git",
   "keywords": [
-    "carbon-design-system"
+    "carbon-design-system ibm-dotcom-library"
   ],
   "scripts": {
     "bootstrap": "lerna bootstrap --hoist",


### PR DESCRIPTION
Replace instances of `Carbon Design System` with `IBM.com Library`

#### Changelog

**Changed**

- Change `Carbon Design System` to `IBM.com Library`
- Update repository path `IBM/carbon-addons-dotcom` → `carbon-design-system/dotcom-library`